### PR TITLE
add check for CFDiv

### DIFF
--- a/rules/lucee.missingtags.rules.json
+++ b/rules/lucee.missingtags.rules.json
@@ -292,5 +292,19 @@
         "bulkcheck": false,
         "tagname": "",
         "functionname": "checkCode"
+    },
+    {
+        "pattern": "<cfdiv\\s+",
+        "message": "cfdiv tag is not supported in Lucee",
+        "componentname": "CodeChecker",
+        "category": "LuceeMissingTags",
+        "name": "cfdiv Tag",
+        "passonmatch": false,
+        "extensions": "cfm,cfc",
+        "severity": "5",
+        "customcode": "",
+        "bulkcheck": false,
+        "tagname": "",
+        "functionname": "checkCode"
     }
 ]


### PR DESCRIPTION
ran into the use of cfdiv today, while it may technically be "supported" by Lucee, it doesn't work and we should flag this.