### PR TITLE
Add excludePaths attribute for global and rules config

### DIFF
--- a/models/RulesService.cfc
+++ b/models/RulesService.cfc
@@ -58,7 +58,8 @@ component accessors="true" {
 	        "customcode": "",
 	        "bulkcheck": false,
 	        "tagname": "",
-	        "functionname": "checkCode"
+	        "functionname": "checkCode", 
+	        "excludePaths": [] 
 	    };
 	    
 	    rule = defaultRule.append( rule, true );

--- a/rules/bp.casesensitivity.rules.json
+++ b/rules/bp.casesensitivity.rules.json
@@ -11,7 +11,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "arrayFindAll\\(",
@@ -25,7 +26,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "arrayFind\\(",
@@ -39,7 +41,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "compare\\(",
@@ -53,7 +56,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "find\\(",
@@ -67,7 +71,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "listContains\\(",
@@ -81,7 +86,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "listFind\\(",
@@ -95,7 +101,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "listValueCount\\(",
@@ -109,7 +116,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "REFind\\(",
@@ -123,7 +131,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "REMatch\\(",
@@ -137,7 +146,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "replace\\(",
@@ -151,7 +161,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "REReplace\\(",
@@ -165,7 +176,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     }
     
 ]

--- a/rules/bp.securityrisks.rules.json
+++ b/rules/bp.securityrisks.rules.json
@@ -11,7 +11,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "cfexecute\\(",
@@ -25,7 +26,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cffile\\s+",
@@ -39,7 +41,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "fileRead\\(",
@@ -53,7 +56,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cffileupload\\s+",
@@ -67,7 +71,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "cffileupload\\(",
@@ -81,7 +86,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfftp\\s+",
@@ -95,7 +101,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "cfftp\\(",
@@ -109,7 +116,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfdirectory\\s+",
@@ -123,7 +131,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "directoryList\\(",
@@ -137,7 +146,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfregistry\\s+",
@@ -151,7 +161,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "cfregistry\\(",
@@ -165,7 +176,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfadmin\\s+",
@@ -179,7 +191,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "cfadmin\\(",
@@ -193,7 +206,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfhttp\\s+",
@@ -207,7 +221,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "cfhttp\\(",
@@ -221,7 +236,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "createObject\\(.*\\042.*java.*\\042",
@@ -235,7 +251,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "createObject\\(.*'.*java.*'",
@@ -249,7 +266,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfobject\\s+'.*java.*'|<cfobject\\s+\\042.*java.*\\042",
@@ -263,7 +281,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "cfobject\\(.*'.*java.*'|cfobject\\(.*\\042.*java.*\\042",
@@ -277,7 +296,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     }
     
 ]    

--- a/rules/core.extra.rules.json
+++ b/rules/core.extra.rules.json
@@ -11,7 +11,8 @@
         "customcode": "",
         "bulkcheck": true,
         "tagname": "",
-        "functionname": "go"
+        "functionname": "go", 
+        "excludePaths": []
     },
     {
         "pattern": "",
@@ -25,6 +26,7 @@
         "customcode": "",
         "bulkcheck": true,
         "tagname": "",
-        "functionname": "runVarscoper"
+        "functionname": "runVarscoper", 
+        "excludePaths": []
     }
 ]

--- a/rules/core.maintenance.rules.json
+++ b/rules/core.maintenance.rules.json
@@ -11,7 +11,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfdump|writeDump\\(",
@@ -25,7 +26,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cflog|writeLog\\(",
@@ -39,7 +41,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "console\\.log\\(",
@@ -53,6 +56,7 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     }
 ]

--- a/rules/core.performance.rules.json
+++ b/rules/core.performance.rules.json
@@ -11,7 +11,8 @@
         "customcode": "",
         "bulkcheck": true,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "parameterExists\\(",
@@ -25,7 +26,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "isDefined\\(",
@@ -39,7 +41,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "Evaluate(?=\\()",
@@ -53,7 +56,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "[^\\w]DE(?=\\()",
@@ -67,7 +71,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "iif(?=\\()",
@@ -81,7 +86,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "StructFind(?=\\()",
@@ -95,7 +101,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "DecrementValue(?=\\()",
@@ -109,7 +116,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "IncrementValue(?=\\()",
@@ -123,7 +131,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "is\\s+\\042\\042|eq\\s+\\042\\042|is\\s+not\\s+\\042\\042|neq\\s+\\042\\042|is\\s+\\047\\047|eq\\s+\\047\\047|is\\s+not\\s+\\047\\047|neq\\s+\\047\\047",
@@ -137,7 +146,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "setVariable\\(",
@@ -151,6 +161,7 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     }
 ]

--- a/rules/core.standards.rules.json
+++ b/rules/core.standards.rules.json
@@ -11,7 +11,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "\\b(form|application|url|session|cgi|client|request|cookie)(?=(\\[|\\.\\w))",
@@ -25,7 +26,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "is\\s+true|is\\s+not\\s+true|is\\s+false|is\\s+not\\s+false",
@@ -39,7 +41,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "is\\s+[0-9]+|is\\s+not\\s+[0-9]+|eq\\s+\\042[A-Za-z]+\\042|eq\\s+\\042[0-9]+\\042|neq\\s+\\042[A-Z][a-z]+\\042|neq\\s+\\042[0-9]+\\042",
@@ -53,7 +56,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "\\+\\s+\\042[0-9]\\042|\\-\\s+\\042[0-9]\\042|\\*\\s+\\042[0-9]\\042|\\/\\s+\\042[0-9]\\042|\\%\\s+\\042[0-9]\\042",
@@ -67,7 +71,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "\\&\\s+[0-9]",
@@ -81,7 +86,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfcatch[\\W]+[^\\<cf][\\W]+</cfcatch|<cfcatch></cfcatch>|<cfcatch>\\W+</cfcatch>",
@@ -95,7 +101,8 @@
         "customcode": "",
         "bulkcheck": true,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": ".*output=\\042\\s*true\\s*\\042|.*output=\\s*true\\s*",
@@ -109,7 +116,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "cfcomponent|cffunction",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "function init\\(|<cffunction.*name=\\042init\\042",
@@ -123,7 +131,8 @@
         "customcode": "",
         "bulkcheck": true,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "function onMissingMethod\\(|<cffunction.*name=\\042onMissingMethod\\042",
@@ -137,7 +146,8 @@
         "customcode": "",
         "bulkcheck": true,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": ".*hint=\\042\\w+.*\\042",
@@ -151,7 +161,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "cfcomponent|cffunction|cfargument",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "ArrayNew\\(1\\)",
@@ -165,7 +176,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "datasource=.*arguments",
@@ -179,6 +191,7 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     }
 ]

--- a/rules/core.standards.rules.json
+++ b/rules/core.standards.rules.json
@@ -193,5 +193,37 @@
         "tagname": "",
         "functionname": "checkCode", 
         "excludePaths": []
+    },
+    {
+        "pattern": "\\b(this)(?=(\\[|\\.\\w))",
+        "message": "Avoid using THIS scoped variables within a CFC; prefer properties/private variables with getter/setter methods.",
+        "componentname": "CodeChecker",
+        "category": "Edge - Standards",
+        "name": "Don't use THIS scoped variables in a CFC",
+        "passonmatch": false,
+        "extensions": "cfc",
+        "severity": "4",
+        "customcode": "",
+        "bulkcheck": false,
+        "tagname": "",
+        "functionname": "checkCode", 
+        "excludePaths": [
+            "Application.cfc"
+        ]
+    },
+    {
+        "pattern": "\\b(var local[= ]+)",
+        "message": "Explicitly declaring the local struct was only required in CF versions prior to 9; the local scope is implicit, and declaring it will break in recent versions of CF.",
+        "componentname": "CodeChecker",
+        "category": "Edge - Standards",
+        "name": "Don't declare var local in a CFC",
+        "passonmatch": false,
+        "extensions": "cfc",
+        "severity": "5",
+        "customcode": "",
+        "bulkcheck": false,
+        "tagname": "",
+        "functionname": "checkCode", 
+        "excludePaths": []
     }
 ]

--- a/rules/disabled/core.security.rules.json
+++ b/rules/disabled/core.security.rules.json
@@ -11,7 +11,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cffile|<input.*type=\\042file\\042",
@@ -25,6 +26,7 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     }
 ]

--- a/rules/lucee.missingtags.rules.json
+++ b/rules/lucee.missingtags.rules.json
@@ -11,7 +11,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfcalendar\\s+",
@@ -25,7 +26,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfexchange\\s+",
@@ -39,7 +41,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cffileupload\\s+",
@@ -53,7 +56,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfformgroup\\s+",
@@ -67,7 +71,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfformitem\\s+",
@@ -81,7 +86,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfgraph\\s+",
@@ -95,7 +101,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfgrid\\s+",
@@ -109,7 +116,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfmenu\\s+",
@@ -123,7 +131,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfNTauthenticate\\s+",
@@ -137,7 +146,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfpdfform\\s+",
@@ -151,7 +161,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfpdfformparam\\s+",
@@ -165,7 +176,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfpod\\s+",
@@ -179,7 +191,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfpresent\\s+",
@@ -193,7 +206,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfprint\\s+",
@@ -207,7 +221,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfreport\\s+",
@@ -221,7 +236,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfspreadsheet\\s+",
@@ -235,7 +251,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfsprydataset\\s+",
@@ -249,7 +266,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cftextarea\\s+",
@@ -263,7 +281,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cftooltip\\s+",
@@ -277,7 +296,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cftree\\s+",
@@ -291,7 +311,8 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     },
     {
         "pattern": "<cfdiv\\s+",
@@ -305,6 +326,7 @@
         "customcode": "",
         "bulkcheck": false,
         "tagname": "",
-        "functionname": "checkCode"
+        "functionname": "checkCode", 
+        "excludePaths": []
     }
 ]


### PR DESCRIPTION
Add excludePaths attribute to allow path exclusions in both global config and for individual rules.
- excludePaths in .codechecker.json will prevent processing of those files whose paths contain one of the strings provided.
- excludePaths in rule definitions will cause the rule to not fire for those files whose paths contain one of the strings provided.