### PR TITLE
Add capability to ignore lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ local.properties
 # PDT-specific
 .buildpath
 
+testbox
+
 
 #################
 ## Visual Studio

--- a/box.json
+++ b/box.json
@@ -9,7 +9,8 @@
         "tests"
     ],
     "installPaths":{
-        "cbjavaloader":"modules/cbjavaloader/"
+        "cbjavaloader":"modules/cbjavaloader/",
+        "testbox":"testbox/"
     },
     "location":"coldbox-modules/codechecker-core#v1.1.1",
     "name":"CodeChecker Core",
@@ -26,5 +27,8 @@
     "shortDescription":"The core service for CodeChecker",
     "slug":"codechecker-core",
     "type":"modules",
-    "version":"1.1.1"
+    "version":"1.1.1",
+    "devDependencies":{
+        "testbox":"^3.2.0+356"
+    }
 }

--- a/models/DisabledRulesService.cfc
+++ b/models/DisabledRulesService.cfc
@@ -1,0 +1,97 @@
+component {
+	DisabledRulesService function init() {
+		return this;
+	}
+
+
+	struct function parseFromFile( required string filepath ) {
+		local.dataFile = fileOpen( arguments.filepath, "read" );
+		local.lineNumber = 0;
+		local.skips = {};
+
+		while ( !fileIsEOF( local.dataFile ) ) {
+			local.lineNumber++;
+			local.line = fileReadLine( local.dataFile );
+
+			if ( NOT StructKeyExists( local.skips, local.lineNumber ) ) {
+				local.skips[ local.lineNumber ] = [];
+			}
+
+			local.skips[ local.lineNumber + 1 ] = [];
+
+
+			arrayAppend(
+				local.skips[ local.lineNumber ],
+				this.detectForLine( line: local.line, pattern: "disable-line" ),
+				true
+			);
+
+			arrayAppend(
+				local.skips[ local.lineNumber + 1 ],
+				this.detectForLine( line: local.line, pattern: "disable-next-line" ),
+				true
+			);
+		}
+
+		fileClose( local.dataFile );
+
+		return local.skips;
+	}
+
+
+	public boolean function shouldSkipLine(
+		required string line,
+		required struct ruleItem,
+		array disabledRules = []
+	) {
+		for ( local.disabledRule in arguments.disabledRules ) {
+			// Skip if the user didn't provide any rules (i.e. skip everything)
+			if ( local.disabledRule.category == "_ALL" ) {
+				return true;
+			}
+
+			// Skip when the user has elected to skip this rule's category
+			if ( not len( local.disabledRule.name ) and local.disabledRule.category == arguments.ruleItem.category ) {
+				return true;
+			}
+
+			// Skip when the user has elected to skip this specific rule
+			if ( local.disabledRule.category == arguments.ruleItem.category and local.disabledRule.name == arguments.ruleItem.name ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
+	package array function detectForLine(required string line, required string pattern) {
+		if ( !reFindNoCase( ".*codechecker\s#arguments.pattern#", arguments.line ) ) {
+			return [];
+		}
+
+		local.matches = reReplaceNoCase( arguments.line, ".*codechecker\s#arguments.pattern#(.*?)(\*\/|--->)?$", "\1" );
+
+		if ( len( trim( local.matches ) ) == 0 ) {
+			return [
+				{
+					"category": "_ALL",
+					"name": ""
+				}
+			];
+		}
+
+		local.rules = [];
+
+		for ( local.match in listToArray( local.matches, "|" ) ) {
+			local.match = trim( local.match );
+
+			arrayAppend(local.rules, {
+				"category": trim( listFirst( local.match, ":" ) ),
+				"name": trim( listRest( local.match, ":" ) )
+			});
+		}
+
+		return local.rules;
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ```
-   ______          __     ________              __                ______              
-  / ____/___  ____/ /__  / ____/ /_  ___  _____/ /_____  _____   / ____/___  ________ 
+   ______          __     ________              __                ______
+  / ____/___  ____/ /__  / ____/ /_  ___  _____/ /_____  _____   / ____/___  ________
  / /   / __ \/ __  / _ \/ /   / __ \/ _ \/ ___/ //_/ _ \/ ___/  / /   / __ \/ ___/ _ \
 / /___/ /_/ / /_/ /  __/ /___/ / / /  __/ /__/ ,< /  __/ /     / /___/ /_/ / /  /  __/
 \____/\____/\__,_/\___/\____/_/ /_/\___/\___/_/|_|\___/_/      \____/\____/_/   \___/
@@ -16,3 +16,27 @@ You probably want to use these services via:
 * The CommandBox Codechecker CLI command https://github.com/commandbox-modules/commandbox-codechecker
 
 These services can be used directly in any implementation you choose, but you'll likely want to use one of the projects above, both of which bundle this core library.
+
+# Ignoring rules
+Individual lines can be ignored in one of two ways:
+
+`codechecker disable-line`
+
+`codechecker disable-next-line`
+
+Both tag & script syntax are supported, as well as multi-line & single-line comment syntax (e.g. `//` or `/* */`)
+
+After the invocation above, specific rules or categories can be provided:
+```
+// Disable a category titled "Formatters"
+codechecker disable-line Formatters
+
+// Disable categories titled "Formatters" and "Standards"
+codechecker disable-line Formatters | Standards
+
+// Disable the rule titled "htmlEditFormat" in the category "Formatters"
+codechecker disable-line Formatters: htmlEditFormat
+```
+
+## Caveat
+Support for ignoring blocks of code or whole files has not been implemented.

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -1,0 +1,22 @@
+/**
+* Copyright Since 2005 Ortus Solutions, Corp
+* www.ortussolutions.com
+**************************************************************************************
+*/
+component{
+	this.name = "A TestBox Runner Suite " & hash( getCurrentTemplatePath() );
+	// any other application.cfc stuff goes below:
+	this.sessionManagement = true;
+
+	// any mappings go here, we create one that points to the root called test.
+	this.mappings[ "/tests" ] = getDirectoryFromPath( getCurrentTemplatePath() );
+	this.mappings[ "/core" ] = expandPath("../");
+
+	// any orm definitions go here.
+
+	// request start
+	public boolean function onRequestStart( String targetPage ){
+
+		return true;
+	}
+}

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -1,0 +1,13 @@
+﻿<cfsetting showDebugOutput="false">
+<!--- Executes all tests in the 'specs' folder with simple reporter by default --->
+<cfparam name="url.reporter" 		default="simple">
+<cfparam name="url.directory" 		default="tests.specs">
+<cfparam name="url.recurse" 		default="true" type="boolean">
+<cfparam name="url.bundles" 		default="">
+<cfparam name="url.labels" 			default="">
+<cfparam name="url.reportpath" 		default="#expandPath( "/tests/results" )#">
+<cfparam name="url.propertiesFilename" 	default="TEST.properties">
+<cfparam name="url.propertiesSummary" 	default="false" type="boolean">
+
+<!--- Include the TestBox HTML Runner --->
+<cfinclude template="/testbox/system/runners/HTMLRunner.cfm" >

--- a/tests/specs/DisabledRulesService.cfc
+++ b/tests/specs/DisabledRulesService.cfc
@@ -1,0 +1,370 @@
+component extends="testbox.system.BaseSpec" {
+	function run() {
+		var service = getMockedService();
+		var testCases = getTestCases();
+
+		story("instructions to disable execution on an individual line can be determined", function() {
+			for (var testCase in testCases) {
+				given("a prefix of '#testCase.prefix#' and a suffix of '#testCase.suffix#'", function() {
+					when("disabling all rules ('disable-line')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-line#testCase.suffix#",
+							pattern: "disable-line"
+						);
+
+						then("there should be one match", function() {
+							expect( matches ).toHaveLength( 1 );
+						});
+
+						then("the disabled rule's category should be '_ALL'", function() {
+							expect( matches[1].category ).toBe( "_ALL" );
+						});
+
+						then("the disabled rule's name should be empty", function() {
+							expect( matches[1].name ).toBe( "" );
+						});
+					});
+
+					when("disabling a category ('disable-line Rule Category')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-line Rule Category#testCase.suffix#",
+							pattern: "disable-line"
+						);
+
+						then("there should be one match", function() {
+							expect( matches ).toHaveLength( 1 );
+						});
+
+						then("the disabled rule's category should be 'Rule Category'", function() {
+							expect( matches[1].category ).toBe( "Rule Category" );
+						});
+
+						then("the disabled rule's name should be ''", function() {
+							expect( matches[1].name ).toBe( "" );
+						});
+					});
+
+					when("disabling one rule in a category ('disable-line Rule Category: Rule Item')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-line Rule Category: Rule Item#testCase.suffix#",
+							pattern: "disable-line"
+						);
+
+						then("there should be one match", function() {
+							expect( matches ).toHaveLength( 1 );
+						});
+
+						then("the disabled rule's category should be 'Rule Category'", function() {
+							expect( matches[1].category ).toBe( "Rule Category" );
+						});
+
+						then("the disabled rule's name should be 'Rule Item'", function() {
+							expect( matches[1].name ).toBe( "Rule Item" );
+						});
+					});
+
+					when("disabling multiple categories ('disable-line Rule Category 1 | Rule Category 2')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-line Rule Category 1 | Rule Category 2#testCase.suffix#",
+							pattern: "disable-line"
+						);
+
+						then("there should be two matches", function() {
+							expect( matches ).toHaveLength( 2 );
+						});
+
+						then("the first disabled rule's category should be 'Rule Category 1'", function() {
+							expect( matches[1].category ).toBe( "Rule Category 1" );
+						});
+
+						then("the first disabled rule's name should be ''", function() {
+							expect( matches[1].name ).toBe( "" );
+						});
+
+						then("the second disabled rule's category should be 'Rule Category 2'", function() {
+							expect( matches[2].category ).toBe( "Rule Category 2" );
+						});
+
+						then("the second disabled rule's name should be ''", function() {
+							expect( matches[2].name ).toBe( "" );
+						});
+					});
+
+					when("disabling an entire category followed by an individual rule ('disable-line Rule Category 1 | Rule Category 2: Rule Item 3')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-line Rule Category 1 | Rule Category 2: Rule Item 3#testCase.suffix#",
+							pattern: "disable-line"
+						);
+
+						then("there should be two matches", function() {
+							expect( matches ).toHaveLength( 2 );
+						});
+
+						then("the first disabled rule's category should be 'Rule Category 1'", function() {
+							expect( matches[1].category ).toBe( "Rule Category 1" );
+						});
+
+						then("the first disabled rule's name should be ''", function() {
+							expect( matches[1].name ).toBe( "" );
+						});
+
+						then("the second disabled rule's category should be 'Rule Category 2'", function() {
+							expect( matches[2].category ).toBe( "Rule Category 2" );
+						});
+
+						then("the second disabled rule's name should be 'Rule Item 3'", function() {
+							expect( matches[2].name ).toBe( "Rule Item 3" );
+						});
+					});
+
+					when("disabling an individual rule followed by an entire category ('disable-line Rule Category 1: Rule Item 2 | Rule Category 3')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-line Rule Category 1: Rule Item 2 | Rule Category 3#testCase.suffix#",
+							pattern: "disable-line"
+						);
+
+						then("there should be two matches", function() {
+							expect( matches ).toHaveLength( 2 );
+						});
+
+						then("the first disabled rule's category should be 'Rule Category 1'", function() {
+							expect( matches[1].category ).toBe( "Rule Category 1" );
+						});
+
+						then("the first disabled rule's name should be 'Rule Item 2'", function() {
+							expect( matches[1].name ).toBe( "Rule Item 2" );
+						});
+
+						then("the second disabled rule's category should be 'Rule Category 3'", function() {
+							expect( matches[2].category ).toBe( "Rule Category 3" );
+						});
+
+						then("the second disabled rule's name should be ''", function() {
+							expect( matches[2].name ).toBe( "" );
+						});
+					});
+
+					when("disabling multiple rules ('disable-line Rule Category 1: Rule Item 2 | Rule Category 3: Rule Item 4')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-line Rule Category 1: Rule Item 2 | Rule Category 3: Rule Item 4#testCase.suffix#",
+							pattern: "disable-line"
+						);
+
+						then("there should be two matches", function() {
+							expect( matches ).toHaveLength( 2 );
+						});
+
+						then("the first disabled rule's category should be 'Rule Category 1'", function() {
+							expect( matches[1].category ).toBe( "Rule Category 1" );
+						});
+
+						then("the first disabled rule's name should be 'Rule Item 2'", function() {
+							expect( matches[1].name ).toBe( "Rule Item 2" );
+						});
+
+						then("the second disabled rule's category should be 'Rule Category 3'", function() {
+							expect( matches[2].category ).toBe( "Rule Category 3" );
+						});
+
+						then("the second disabled rule's name should be 'Rule Item 4'", function() {
+							expect( matches[2].name ).toBe( "Rule Item 4" );
+						});
+					});
+				});
+			}
+		});
+
+		story("instructions to disable execution for the next line can be determined", function() {
+			for (var testCase in testCases) {
+				given("a prefix of '#testCase.prefix#' and a suffix of '#testCase.suffix#'", function() {
+					when("disabling all rules ('disable-next-line')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-next-line#testCase.suffix#",
+							pattern: "disable-next-line"
+						);
+
+						then("there should be one match", function() {
+							expect( matches ).toHaveLength( 1 );
+						});
+
+						then("the disabled rule's category should be '_ALL'", function() {
+							expect( matches[1].category ).toBe( "_ALL" );
+						});
+
+						then("the disabled rule's name should be empty", function() {
+							expect( matches[1].name ).toBe( "" );
+						});
+					});
+
+					when("disabling a category ('disable-next-line Rule Category')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-next-line Rule Category#testCase.suffix#",
+							pattern: "disable-next-line"
+						);
+
+						then("there should be one match", function() {
+							expect( matches ).toHaveLength( 1 );
+						});
+
+						then("the disabled rule's category should be 'Rule Category'", function() {
+							expect( matches[1].category ).toBe( "Rule Category" );
+						});
+
+						then("the disabled rule's name should be ''", function() {
+							expect( matches[1].name ).toBe( "" );
+						});
+					});
+
+					when("disabling one rule in a category ('disable-next-line Rule Category: Rule Item')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-next-line Rule Category: Rule Item#testCase.suffix#",
+							pattern: "disable-next-line"
+						);
+
+						then("there should be one match", function() {
+							expect( matches ).toHaveLength( 1 );
+						});
+
+						then("the disabled rule's category should be 'Rule Category'", function() {
+							expect( matches[1].category ).toBe( "Rule Category" );
+						});
+
+						then("the disabled rule's name should be 'Rule Item'", function() {
+							expect( matches[1].name ).toBe( "Rule Item" );
+						});
+					});
+
+					when("disabling multiple categories ('disable-next-line Rule Category 1 | Rule Category 2')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-next-line Rule Category 1 | Rule Category 2#testCase.suffix#",
+							pattern: "disable-next-line"
+						);
+
+						then("there should be two matches", function() {
+							expect( matches ).toHaveLength( 2 );
+						});
+
+						then("the first disabled rule's category should be 'Rule Category 1'", function() {
+							expect( matches[1].category ).toBe( "Rule Category 1" );
+						});
+
+						then("the first disabled rule's name should be ''", function() {
+							expect( matches[1].name ).toBe( "" );
+						});
+
+						then("the second disabled rule's category should be 'Rule Category 2'", function() {
+							expect( matches[2].category ).toBe( "Rule Category 2" );
+						});
+
+						then("the second disabled rule's name should be ''", function() {
+							expect( matches[2].name ).toBe( "" );
+						});
+					});
+
+					when("disabling an entire category followed by an individual rule ('disable-next-line Rule Category 1 | Rule Category 2: Rule Item 3')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-next-line Rule Category 1 | Rule Category 2: Rule Item 3#testCase.suffix#",
+							pattern: "disable-next-line"
+						);
+
+						then("there should be two matches", function() {
+							expect( matches ).toHaveLength( 2 );
+						});
+
+						then("the first disabled rule's category should be 'Rule Category 1'", function() {
+							expect( matches[1].category ).toBe( "Rule Category 1" );
+						});
+
+						then("the first disabled rule's name should be ''", function() {
+							expect( matches[1].name ).toBe( "" );
+						});
+
+						then("the second disabled rule's category should be 'Rule Category 2'", function() {
+							expect( matches[2].category ).toBe( "Rule Category 2" );
+						});
+
+						then("the second disabled rule's name should be 'Rule Item 3'", function() {
+							expect( matches[2].name ).toBe( "Rule Item 3" );
+						});
+					});
+
+					when("disabling an individual rule followed by an entire category ('disable-next-line Rule Category 1: Rule Item 2 | Rule Category 3')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-next-line Rule Category 1: Rule Item 2 | Rule Category 3#testCase.suffix#",
+							pattern: "disable-next-line"
+						);
+
+						then("there should be two matches", function() {
+							expect( matches ).toHaveLength( 2 );
+						});
+
+						then("the first disabled rule's category should be 'Rule Category 1'", function() {
+							expect( matches[1].category ).toBe( "Rule Category 1" );
+						});
+
+						then("the first disabled rule's name should be 'Rule Item 2'", function() {
+							expect( matches[1].name ).toBe( "Rule Item 2" );
+						});
+
+						then("the second disabled rule's category should be 'Rule Category 3'", function() {
+							expect( matches[2].category ).toBe( "Rule Category 3" );
+						});
+
+						then("the second disabled rule's name should be ''", function() {
+							expect( matches[2].name ).toBe( "" );
+						});
+					});
+
+					when("disabling multiple rules ('disable-next-line Rule Category 1: Rule Item 2 | Rule Category 3: Rule Item 4')", function() {
+						var matches = service.detectForLine(
+							line: "some irrelevant content #testCase.prefix#codechecker disable-next-line Rule Category 1: Rule Item 2 | Rule Category 3: Rule Item 4#testCase.suffix#",
+							pattern: "disable-next-line"
+						);
+
+						then("there should be two matches", function() {
+							expect( matches ).toHaveLength( 2 );
+						});
+
+						then("the first disabled rule's category should be 'Rule Category 1'", function() {
+							expect( matches[1].category ).toBe( "Rule Category 1" );
+						});
+
+						then("the first disabled rule's name should be 'Rule Item 2'", function() {
+							expect( matches[1].name ).toBe( "Rule Item 2" );
+						});
+
+						then("the second disabled rule's category should be 'Rule Category 3'", function() {
+							expect( matches[2].category ).toBe( "Rule Category 3" );
+						});
+
+						then("the second disabled rule's name should be 'Rule Item 4'", function() {
+							expect( matches[2].name ).toBe( "Rule Item 4" );
+						});
+					});
+				});
+			}
+		});
+	}
+
+
+	component function getMockedService() {
+		return makePublic(new core.models.DisabledRulesService(), "detectForLine");
+	}
+
+
+	array function getTestCases() {
+		return [
+			{ prefix: "// ", suffix: "" },
+			{ prefix: "// ", suffix: " " },
+			{ prefix: "// ", suffix: chr(9) },
+			{ prefix: "/* ", suffix: " */" },
+			{ prefix: "/*", suffix: " */" },
+			{ prefix: "/* ", suffix: "*/" },
+			{ prefix: "/*", suffix: "*/" },
+			{ prefix: "<!--- ", suffix: " --->" },
+			{ prefix: "<!---", suffix: " --->" },
+			{ prefix: "<!--- ", suffix: "--->" },
+			{ prefix: "<!---", suffix: "--->" }
+		];
+	}
+}

--- a/tests/test.xml
+++ b/tests/test.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<!--
+This ANT build can be used to execute your tests with automation using our included runner.cfm.  
+You can executes directories, bundles and so much more.  It can also produce JUnit reports using the
+ANT junitreport tag.  This is meant to be a template for you to spice up.
+
+There are two targets you can use: run and run-junit
+
+Execute the default 'run' target
+ant -f test.xml
+OR
+ant -f test.xml run
+
+Execute the 'run-junit' target
+ant -f test.xml run-junit
+
+PLEASE NOTE THAT YOU MUST ALTER THE RUNNER'S URL ACCORDING TO YOUR ENVIRONMENT.
+-->
+<project name="testbox-ant-runner" default="run" basedir=".">
+	
+	<!-- THE URL TO THE RUNNER, PLEASE CHANGE ACCORDINGLY-->
+	<property name="url.runner"			value="http://localhost/test-runner/runner.cfm?"/>
+	<!-- FILL OUT THE BUNDLES TO TEST, CAN BE A LIST OF CFC PATHS -->
+	<property name="test.bundles"		value="" />
+	<!-- FILL OUT THE DIRECTORY MAPPING TO TEST -->
+	<property name="test.directory"		value="tests.specs" />
+	<!-- FILL OUT IF YOU WANT THE DIRECTORY RUNNER TO RECURSE OR NOT -->
+	<property name="test.recurse"		value="true" />
+	<!-- FILL OUT THE LABELS YOU WANT TO APPLY TO THE TESTS -->
+	<property name="test.labels"		value="" />
+	<!-- FILL OUT THE TEST REPORTER YOU WANT, AVAILABLE REPORTERS ARE: ANTJunit, Codexwiki, console, dot, doc, json, junit, min, raw, simple, tap, text, xml -->
+	<property name="test.reporter"		value="simple" />
+	<!-- FILL OUT WHERE REPORTING RESULTS ARE STORED --> 
+	<property name="report.dir"  		value="${basedir}/results" />
+	<property name="junitreport.dir"  	value="${report.dir}/junitreport" />
+
+	<target name="init" description="Init the tests">
+		<delete dir="${junitreport.dir}" />
+		<mkdir dir="${junitreport.dir}" />
+		<delete>
+			<fileset dir="${report.dir}">  
+				<include name="TEST-*.xml"/>
+				<include name="TEST.properties"/>
+			</fileset>
+		</delete>
+		<tstamp prefix="start">
+			<format property="TODAY" pattern="MM-dd-YYYY hh:mm:ss aa"/>
+		</tstamp>
+		<concat destfile="${report.dir}/latestrun.log">Tests ran at ${start.TODAY}</concat>
+	</target>
+	
+	<target name="run" depends="init" description="Run our tests and produce awesome results">  
+
+		<!-- Directory Runner 
+			Executes recursively all tests in the passed directory and stores the results in the 
+			'dest' param.  So if you want to rename the file, do so here.
+
+			 Available params for directory runner:
+			 - Reporter
+			 - Directory
+			 - Recurse
+			 - Labels
+		-->
+		<get dest="${report.dir}/results.html" 
+			 src="${url.runner}&amp;directory=${test.directory}&amp;recurse=${test.recurse}&amp;reporter=${test.reporter}&amp;labels=${test.labels}&amp;propertiesSummary=true" 
+			 verbose="true"/>
+		
+		<!-- Bundles Runner
+			You can also run tests for specific bundles by using the runner with the bundles params
+
+			Available params for runner:
+			 - Reporter
+			 - Bundles
+			 - Labels
+
+		<get dest="${report.dir}/results.html" 
+			 src="${url.runner}&amp;bundles=${test.bundles}&amp;reporter=${test.reporter}&amp;labels=${test.labels}&amp;propertiesSummary=true" 
+			 verbose="true"/>
+		 -->
+		
+		<!-- Read Result Properties -->
+		<property file="${report.dir}/TEST.properties"/>
+		<!-- Echo them out -->
+		<echoproperties regex="^(test|total).*"/>
+		<!-- Fail build if they failed -->
+		<fail if="test.failed"/>
+	</target>
+
+	<target name="run-junit" depends="init" description="Run our tests and produce ANT JUnit reports">  
+
+		<!-- Directory Runner 
+			Executes recursively all tests in the passed directory and stores the results in the 
+			'dest' param.  So if you want to rename the file, do so here.
+
+			 Available params for directory runner:
+			 - Reporter = ANTJunit fixed
+			 - Directory
+			 - Recurse
+			 - Labels
+			 - ReportPath : The path where reports will be stored, by default it is the ${report.dir} directory.
+		-->
+		<get dest="${report.dir}/results.xml" 
+			 src="${url.runner}&amp;directory=${test.directory}&amp;recurse=${test.recurse}&amp;reporter=ANTJunit&amp;labels=${test.labels}&amp;reportPath=${report.dir}&amp;propertiesSummary=true" 
+			 verbose="true"/>
+		
+		<!-- Bundles Runner
+			You can also run tests for specific bundles by using the runner with the bundles params
+
+			Available params for runner:
+			 - Reporter
+			 - Bundles
+			 - Labels
+
+		<get dest="${report.dir}/results.html" 
+			 src="${url.runner}&amp;bundles=${test.bundles}&amp;reporter=${test.reporter}&amp;labels=${test.labels}&amp;propertiesSummary=true" 
+			 verbose="true"/>
+		 -->
+
+		 <!-- Create fancy junit reports -->
+		<junitreport todir="${junitreport.dir}">  
+			<fileset dir="${report.dir}">  
+				<include name="TEST-*.xml"/>  
+			</fileset>
+			<report format="frames" todir="${junitreport.dir}">
+				<param name="TITLE" expression="My Awesome TestBox Results"/>
+			</report>
+		</junitreport> 
+		
+		<!-- Read Result Properties -->
+		<property file="${report.dir}/TEST.properties"/>
+		<!-- Echo them out -->
+		<echoproperties regex="^(test|total).*"/>
+		<!-- Fail build if they failed -->
+		<fail if="test.failed"/>
+	</target>
+
+</project>


### PR DESCRIPTION
Individual lines can be ignored in one of two ways:
`codechecker disable-line` or `codechecker disable-next-line`

Both tag & script syntax are supported, as well as multi-line & single-line comment syntax.

After the invocation above, a user can specify rules or categories:
`codechecker disable-line Formatters` - disables the entire category
`codechecker disable-line Formatters | Standards` - disables both categories
`codechecker disable-line Formatters: htmlEditFormat` - disables an individual rule

Support for ignoring blocks or whole files is not included